### PR TITLE
context['waehrung'] is always true / line.amount_currency from int to…

### DIFF
--- a/ecoservice_financeinterface_datev/ecofi.py
+++ b/ecoservice_financeinterface_datev/ecofi.py
@@ -181,7 +181,8 @@ class ecofi(osv.osv):
                     lineumsatz = Decimal(str(0))
                     lineumsatz += Decimal(str(line.debit))
                     lineumsatz -= Decimal(str(line.credit))
-                    if line.amount_currency != 0:
+                    context['waehrung'] = False
+                    if line.amount_currency != 0.0:
                         lineumsatz = Decimal(str(line.amount_currency))
                         context['waehrung'] = True
                     buschluessel = ''  


### PR DESCRIPTION
context['waehrung'] is always true after handling a move in different currency. context['waehrung'] must be set to false to avoid this.
Also a little correction with line.amount_currency which is a fload field, not an int.